### PR TITLE
Strip whitespace when reading Audience nodes

### DIFF
--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -359,7 +359,7 @@ class OneLogin_Saml2_Response(object):
         :rtype: list
         """
         audience_nodes = self.__query_assertion('/saml:Conditions/saml:AudienceRestriction/saml:Audience')
-        return [node.text for node in audience_nodes if node.text is not None]
+        return [node.text.strip() for node in audience_nodes if node.text is not None]
 
     def get_issuers(self):
         """


### PR DESCRIPTION
If the Audience contains leading whitespace, e.g. in the case

```
<Audience>
  https://foo.com/sso
</Audience>
```

Then this will cause the validation to fail, as the real
audience doesn't match "\n  https://foo.com/sso".

Be liberal in what we accept, and strip surrounding whitespace.